### PR TITLE
composer: require christian-riesen/base32 ^1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "christian-riesen/base32": "1.2"
+        "christian-riesen/base32": "^1.2"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Allow newer versions of christian-riesen/base32 to be installed without breaking BC
